### PR TITLE
🌟 New: Adds path and port options

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "chokidar": "^1.6.0",
     "express": "^4.14.0",
+    "meow": "^3.7.0",
     "serve-index": "^1.8.0",
     "serve-static": "^1.11.1",
     "ws": "^1.1.1"


### PR DESCRIPTION
This PR does a few things:
- Adds [Meow](https://github.com/sindresorhus/meow) to handle CLI args
- Adds `--help` flag to display a help screen
- Adds `--port` (`-p`) flag to set port number
- Takes the first non-flag argument and uses it to set the path to load
- Adds error handling for port number: if `EADDRINUSE`, increments port number until available

This resolves #1.
